### PR TITLE
feat: use resend as a mailer

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -7,4 +7,4 @@ node_modules
 /resources/js/routes
 /resources/js/wayfinder
 
-resources/views/mails/**/*.blade.php
+resources/views/emails/**/*.blade.php

--- a/app/Mail/WorkspaceInvitationMail.php
+++ b/app/Mail/WorkspaceInvitationMail.php
@@ -7,6 +7,7 @@ namespace App\Mail;
 use App\Models\WorkspaceInvitation;
 use Illuminate\Bus\Queueable;
 use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Address;
 use Illuminate\Mail\Mailables\Content;
 use Illuminate\Mail\Mailables\Envelope;
 use Illuminate\Queue\SerializesModels;
@@ -29,6 +30,7 @@ final class WorkspaceInvitationMail extends Mailable
     public function envelope(): Envelope
     {
         return new Envelope(
+            from: new Address('no-reply@expensetrackr.app', 'ExpenseTrackr'),
             subject: 'Workspace Invitation',
         );
     }

--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,7 @@
         "meilisearch/meilisearch-php": "1.14.0",
         "nunomaduro/essentials": "@dev",
         "pinkary-project/type-guard": "0.1.0",
+        "resend/resend-php": "0.17.0",
         "sentry/sentry-laravel": "4.13.0",
         "spatie/enum": "3.13.0",
         "spatie/laravel-data": "4.15.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "03715a432fe6d5d3bb827aa288708aa0",
+    "content-hash": "b06e0438fb6aaf919af3ee8d7c646f1d",
     "packages": [
         {
             "name": "afatmustafa/blade-hugeicons",
@@ -1066,16 +1066,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.342.35",
+            "version": "3.342.36",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "3fdb88961cf80775dbaf48a5641c9790d63d1d66"
+                "reference": "9a0ec6b6d503409ae15e090467d3bd6d723b6c6a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/3fdb88961cf80775dbaf48a5641c9790d63d1d66",
-                "reference": "3fdb88961cf80775dbaf48a5641c9790d63d1d66",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/9a0ec6b6d503409ae15e090467d3bd6d723b6c6a",
+                "reference": "9a0ec6b6d503409ae15e090467d3bd6d723b6c6a",
                 "shasum": ""
             },
             "require": {
@@ -1157,9 +1157,9 @@
             "support": {
                 "forum": "https://github.com/aws/aws-sdk-php/discussions",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.342.35"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.342.36"
             },
-            "time": "2025-04-25T18:09:39+00:00"
+            "time": "2025-04-28T18:01:39+00:00"
         },
         {
             "name": "bacon/bacon-qr-code",
@@ -6858,12 +6858,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nunomaduro/essentials.git",
-                "reference": "6b58123cf0d0e8717e6ccde9ee9f841e472c4091"
+                "reference": "1bd3e89209ed6714dfadc76fbc99f4a1e2211973"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nunomaduro/essentials/zipball/6b58123cf0d0e8717e6ccde9ee9f841e472c4091",
-                "reference": "6b58123cf0d0e8717e6ccde9ee9f841e472c4091",
+                "url": "https://api.github.com/repos/nunomaduro/essentials/zipball/1bd3e89209ed6714dfadc76fbc99f4a1e2211973",
+                "reference": "1bd3e89209ed6714dfadc76fbc99f4a1e2211973",
                 "shasum": ""
             },
             "require": {
@@ -6929,7 +6929,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2025-04-24T20:13:10+00:00"
+            "time": "2025-04-29T10:54:37+00:00"
         },
         {
             "name": "nunomaduro/termwind",
@@ -8735,6 +8735,63 @@
                 }
             ],
             "time": "2024-04-27T21:32:50+00:00"
+        },
+        {
+            "name": "resend/resend-php",
+            "version": "v0.17.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/resend/resend-php.git",
+                "reference": "e772153ac74b05ba72ce4d0f96d61418f48ebb3d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/resend/resend-php/zipball/e772153ac74b05ba72ce4d0f96d61418f48ebb3d",
+                "reference": "e772153ac74b05ba72ce4d0f96d61418f48ebb3d",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/guzzle": "^7.5",
+                "php": "^8.1.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.13",
+                "mockery/mockery": "^1.6",
+                "pestphp/pest": "^2.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/Resend.php"
+                ],
+                "psr-4": {
+                    "Resend\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Resend and contributors",
+                    "homepage": "https://github.com/resend/resend-php/contributors"
+                }
+            ],
+            "description": "Resend PHP library.",
+            "homepage": "https://resend.com/",
+            "keywords": [
+                "api",
+                "client",
+                "php",
+                "resend",
+                "sdk"
+            ],
+            "support": {
+                "issues": "https://github.com/resend/resend-php/issues",
+                "source": "https://github.com/resend/resend-php/tree/v0.17.0"
+            },
+            "time": "2025-04-23T20:24:02+00:00"
         },
         {
             "name": "revolt/event-loop",
@@ -14195,16 +14252,16 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.13.0",
+            "version": "1.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "024473a478be9df5fdaca2c793f2232fe788e414"
+                "reference": "1720ddd719e16cf0db4eb1c6eca108031636d46c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/024473a478be9df5fdaca2c793f2232fe788e414",
-                "reference": "024473a478be9df5fdaca2c793f2232fe788e414",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/1720ddd719e16cf0db4eb1c6eca108031636d46c",
+                "reference": "1720ddd719e16cf0db4eb1c6eca108031636d46c",
                 "shasum": ""
             },
             "require": {
@@ -14243,7 +14300,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.0"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.1"
             },
             "funding": [
                 {
@@ -14251,7 +14308,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-02-12T12:17:51+00:00"
+            "time": "2025-04-29T12:36:36+00:00"
         },
         {
             "name": "nunomaduro/collision",

--- a/resources/views/emails/workspace-invitation.blade.php
+++ b/resources/views/emails/workspace-invitation.blade.php
@@ -3,23 +3,23 @@
 @endphp
 
 @component('mail::message')
-    {{ __('You have been invited to join the :workspace workspace!', ['workspace' => $invitation->workspace->name]) }}
+{{ __('You have been invited to join the :workspace workspace!', ['workspace' => $invitation->workspace->name]) }}
 
-    @if (Features::enabled(Features::registration()))
-        {{ __('If you do not have an account, you may create one by clicking the button below. After creating an account, you may click the invitation acceptance button in this email to accept the workspace invitation:') }}
+@if (Features::enabled(Features::registration()))
+    {{ __('If you do not have an account, you may create one by clicking the button below. After creating an account, you may click the invitation acceptance button in this email to accept the workspace invitation:') }}
 
-        @component('mail::button', ['url' => route('register')])
-            {{ __('Create account') }}
-        @endcomponent
-
-        {{ __('If you already have an account, you may accept this invitation by clicking the button below:') }}
-    @else
-        {{ __('You may accept this invitation by clicking the button below:') }}
-    @endif
-
-    @component('mail::button', ['url' => $acceptUrl])
-        {{ __('Accept invitation') }}
+    @component('mail::button', ['url' => route('register')])
+        {{ __('Create account') }}
     @endcomponent
 
-    {{ __('If you did not expect to receive an invitation to this workspace, you may discard this email.') }}
+    {{ __('If you already have an account, you may accept this invitation by clicking the button below:') }}
+@else
+    {{ __('You may accept this invitation by clicking the button below:') }}
+@endif
+
+@component('mail::button', ['url' => $acceptUrl])
+    {{ __('Accept invitation') }}
+@endcomponent
+
+{{ __('If you did not expect to receive an invitation to this workspace, you may discard this email.') }}
 @endcomponent


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Outgoing workspace invitation emails now display "ExpenseTrackr <no-reply@expensetrackr.app>" as the sender.
- **Chores**
	- Updated dependencies to include Resend PHP package.
	- Adjusted formatting in workspace invitation email templates for consistency.
	- Updated configuration to ignore formatting for email view files in the "emails" directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->